### PR TITLE
Ignore muted conversations' messages in the notification badge

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -3,9 +3,14 @@ import path from 'path';
 module.exports = (Franz) => {
   const getMessages = function getMessages() {
     // get unread messages
-    const count = document.querySelector('#hangout-landing-chat iframe')
+    const unread = document.querySelector('#hangout-landing-chat iframe')
       .contentWindow.document.querySelectorAll('.ee')
-      .length;
+
+    // remove muted conversations
+    const count = Array.prototype.filter.call(
+      unread,
+      (entry) => !entry.classList.contains('BN')
+    ).length
 
     // set Franz badge
     Franz.setBadge(count);


### PR DESCRIPTION
### Description
When you disable notifications for a conversation and receive a message in it, Franz still adds a notification badge. This shouldn't happen as you disabled them.

### Motivation and Context
This PR fixes issue [#1106](https://github.com/meetfranz/franz/issues/1106) of [meetfranz/franz](https://github.com/meetfranz/franz)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)